### PR TITLE
Replace black with ruff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ See the [poetry docs](https://python-poetry.org/docs) for more.
 
 # Linting and formatting
 
-Code-style is enforced using [black](https://black.readthedocs.io/) and [flake8](https://flake8.pycqa.org/); import optimisation is handled by [isort](https://pycqa.github.io/isort/) and [autoflake](https://pypi.org/project/autoflake/).  Linting is automatically applied when tox runs tests; if linting fails, you can fix trivial problems with:
+Code-style is enforced using [ruff](https://docs.astral.sh/ruff/) and [flake8](https://flake8.pycqa.org/); import optimisation is handled by [isort](https://pycqa.github.io/isort/) and [autoflake](https://pypi.org/project/autoflake/).  Linting is automatically applied when tox runs tests; if linting fails, you can fix trivial problems with:
 
 ```
 ./toxw -e format

--- a/poetry.lock
+++ b/poetry.lock
@@ -54,28 +54,6 @@ python-versions = ">=3.6"
 tzdata = ["tzdata"]
 
 [[package]]
-name = "black"
-version = "22.12.0"
-description = "The uncompromising code formatter."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
-typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "cachetools"
 version = "5.5.0"
 description = "Extensible memoizing collections and decorators"
@@ -98,17 +76,6 @@ description = "The Real First Universal Charset Detector. Open, modern and activ
 category = "main"
 optional = false
 python-versions = ">=3.7.0"
-
-[[package]]
-name = "click"
-version = "8.1.7"
-description = "Composable command line interface toolkit"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
@@ -402,14 +369,6 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-description = "Type system extensions for programs checked with the mypy type checker."
-category = "dev"
-optional = false
-python-versions = ">=3.5"
-
-[[package]]
 name = "numpy"
 version = "1.24.0"
 description = "Fundamental package for array computing in Python"
@@ -422,14 +381,6 @@ name = "packaging"
 version = "24.1"
 description = "Core utilities for Python packages"
 category = "main"
-optional = false
-python-versions = ">=3.8"
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-category = "dev"
 optional = false
 python-versions = ">=3.8"
 
@@ -652,6 +603,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "ruff"
+version = "0.6.9"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "scipy"
 version = "1.9.3"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -870,7 +829,7 @@ test = ["pytest (>=6,<8.1.0 || >=8.2.0)", "pytest-checkdocs (>=2.4)", "pytest-co
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.13"
-content-hash = "7e94266439e59f230314faf023855afc7f23d5afbcb4d5ab805b02c132f0cee1"
+content-hash = "c9d91b5a097f8d3e3240d546270473115509d5d0b8bdc0fe83674caecfe077b7"
 
 [metadata.files]
 asn1crypto = []
@@ -878,11 +837,9 @@ atomicwrites = []
 attrs = []
 autoflake = []
 "backports.zoneinfo" = []
-black = []
 cachetools = []
 certifi = []
 charset-normalizer = []
-click = []
 colorama = []
 dateparser = []
 decorator = []
@@ -905,10 +862,8 @@ iniconfig = []
 isort = []
 mccabe = []
 more-itertools = []
-mypy-extensions = []
 numpy = []
 packaging = []
-pathspec = []
 pg8000 = []
 platformdirs = []
 pluggy = []
@@ -928,6 +883,7 @@ requests = []
 rsa = []
 "ruamel.yaml" = []
 "ruamel.yaml.clib" = []
+ruff = []
 scipy = []
 scramp = []
 signal-processing-algorithms = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,10 @@ pg8000 = "^1.31.2"
 pytest = "^6.2.2"
 pytz = "2021.1"
 tox = "^3.25.0"
-black = "^22.3.0"
 flake8 = "^4.0.1"
 autoflake = "^1.4"
 isort = "^5.10.1"
+ruff = "^0.6.9"
 
 [tool.pytest.ini_options]
 filterwarnings = [
@@ -39,7 +39,7 @@ filterwarnings = [
 [tool.poetry.scripts]
 hunter = 'hunter.main:main'
 
-[tool.black]
+[tool.ruff]
 line-length = 100
 
 [tool.isort]

--- a/tox.ini
+++ b/tox.ini
@@ -19,20 +19,20 @@ passenv =
     SSH_AUTH_SOCK
 setenv =
     BUILD_DIR = {toxinidir}/build/{envname}
-    BLACK_OPTS =
+    RUFF_OPTS =
     FLAKE8_OPTS = --count --show-source --statistics
     AUTOFLAKE_OPTS = --exclude build --recursive --remove-all-unused-imports
     POETRY_OPTS = -v
     PYTEST_OPTS =
 
     # Linting should be quiet and fast
-    lint: BLACK_OPTS = --quiet --fast
+    lint: RUFF_OPTS = --quiet --fast
     lint: FLAKE8_OPTS =
     lint: POETRY_OPTS = --quiet --no-root
 commands_pre =
     ./poetryw install {env:POETRY_OPTS}
 commands =
-    black {env:BLACK_OPTS} --check --diff .
+    ruff {env:RUFF_OPTS} check --diff .
     autoflake {env:AUTOFLAKE_OPTS} --check .
     isort --check --diff .
     flake8 {env:FLAKE8_OPTS}
@@ -43,7 +43,7 @@ commands =
 # environment
 [testenv:format]
 commands =
-    black .
+    ruff check --fix .
     autoflake {env:AUTOFLAKE_OPTS} --in-place .
     isort .
 


### PR DESCRIPTION
black depends on pathspec that is licensed under MPL 2.0. Even though MPL 2.0 can _maybe_ be included in an ASF project, I'd prefer to simplify the discussion and just replace black with ruff that is licensed as Apache 2.0, does not have any dependencies, and is already used by other Apache projects.